### PR TITLE
Make snapshot syncs faster

### DIFF
--- a/backuppy/__init__.py
+++ b/backuppy/__init__.py
@@ -1,0 +1,30 @@
+import os
+
+
+def assert_path(test, source_path, target_path):
+    """Assert two source and target directory paths are identical.
+
+    :param test: unittest.TestCase
+    :param source_path: str
+    :param target_path: str
+    :raise: AssertionError
+    """
+    for source_dir_path, child_dir_names, child_file_names in os.walk(source_path):
+        target_dir_path = target_path + source_dir_path[len(source_path):]
+        for child_file_name in child_file_names:
+            with open(os.path.join(source_dir_path, child_file_name)) as source_f:
+                with open(os.path.join(target_dir_path, child_file_name)) as target_f:
+                    assert_file(test, source_f, target_f)
+
+
+def assert_file(test, source_f, target_f):
+    """Assert two source and target files are identical.
+
+    :param test: unittest.TestCase
+    :param source_f: File
+    :param target_f: File
+    :raise: AssertionError
+    """
+    source_f.seek(0)
+    target_f.seek(0)
+    test.assertEquals(source_f.read(), target_f.read())

--- a/backuppy/__init__.py
+++ b/backuppy/__init__.py
@@ -9,12 +9,15 @@ def assert_path(test, source_path, target_path):
     :param target_path: str
     :raise: AssertionError
     """
-    for source_dir_path, child_dir_names, child_file_names in os.walk(source_path):
-        target_dir_path = target_path + source_dir_path[len(source_path):]
-        for child_file_name in child_file_names:
-            with open(os.path.join(source_dir_path, child_file_name)) as source_f:
-                with open(os.path.join(target_dir_path, child_file_name)) as target_f:
-                    assert_file(test, source_f, target_f)
+    try:
+        for source_dir_path, child_dir_names, child_file_names in os.walk(source_path):
+            target_dir_path = target_path + source_dir_path[len(source_path):]
+            for child_file_name in child_file_names:
+                with open(os.path.join(source_dir_path, child_file_name)) as source_f:
+                    with open(os.path.join(target_dir_path, child_file_name)) as target_f:
+                        assert_file(test, source_f, target_f)
+    except Exception:
+        raise AssertionError('The paths `%` and `%s` and their contents are not equal.')
 
 
 def assert_file(test, source_f, target_f):

--- a/backuppy/location.py
+++ b/backuppy/location.py
@@ -61,10 +61,10 @@ class Target(Location):
     """Provide a backup target."""
 
     @abc.abstractmethod
-    def snapshot(self, name=None):
+    def snapshot(self, name):
         """Create a new snapshot.
 
-        :param name: Optional[str]
+        :param name: str
         """
         pass
 
@@ -120,13 +120,11 @@ class PathTarget(Target, PathLocation):
         """
         return '/'.join([self.path, 'latest'])
 
-    def snapshot(self, name=None):
+    def snapshot(self, name):
         """Create a new snapshot.
 
-        :param name: Optional[str]
+        :param name: str
         """
-        if name is None:
-            name = new_snapshot_name()
         for args in _new_snapshot_args(name):
             code = subprocess.call(args, cwd=self._path)
             if 0 != code:
@@ -165,13 +163,11 @@ class SshTarget(Target):
             self._notifier.alert('The remote timed out.')
             return False
 
-    def snapshot(self, name=None):
+    def snapshot(self, name):
         """Create a new snapshot.
 
-        :param name: Optional[str]
+        :param name: str
         """
-        if name is None:
-            name = new_snapshot_name()
         with self._connect() as client:
             for args in _new_snapshot_args(name):
                 client.exec_command(' '.join(args))
@@ -224,7 +220,7 @@ class SshTarget(Target):
 
         :return: str
         """
-        return '%s@%s:%d/%s/latest' % (self.user, self.host, self.port, self.path)
+        return '%s@%s:%d%s/latest' % (self.user, self.host, self.port, self.path)
 
 
 class FirstAvailableTarget(Target):
@@ -252,10 +248,10 @@ class FirstAvailableTarget(Target):
         """
         return self._get_available_target().to_rsync()
 
-    def snapshot(self, name=None):
+    def snapshot(self, name):
         """Create a new snapshot.
 
-        :param name: Optional[str]
+        :param name: str
         """
         return self._get_available_target().snapshot(name)
 

--- a/backuppy/task.py
+++ b/backuppy/task.py
@@ -2,6 +2,7 @@
 import subprocess
 
 from backuppy.config import Configuration
+from backuppy.location import new_snapshot_name
 
 
 def backup(configuration):
@@ -26,7 +27,8 @@ def backup(configuration):
 
     notifier.inform('Backing up %s...' % configuration.name)
 
-    target.snapshot()
+    snapshot_name = new_snapshot_name()
+    target.snapshot(snapshot_name)
 
     args = ['rsync', '-ar', '--numeric-ids']
     if configuration.verbose:

--- a/backuppy/tests/test_location.py
+++ b/backuppy/tests/test_location.py
@@ -31,7 +31,7 @@ class NewSnapshotArgsTest(TestCase):
 
 class PathLocationTest(TestCase):
     class PathLocation(PathLocation):
-        def snapshot(self):
+        def snapshot(self, name):
             pass
 
         def to_rsync(self):
@@ -51,11 +51,17 @@ class PathLocationTest(TestCase):
 
 
 class PathTargetTest(TestCase):
+    def test_to_rsync(self):
+        notifier = Mock(Notifier)
+        path = '/var/cache'
+        sut = PathTarget(notifier, path)
+        self.assertEquals(sut.to_rsync(), '/var/cache/latest')
+
     def test_snapshot_without_name(self):
         notifier = Mock(Notifier)
         with TemporaryDirectory() as path:
             sut = PathTarget(notifier, path)
-            sut.snapshot()
+            sut.snapshot('foo')
             self.assertTrue(os.path.exists('/'.join([path, 'latest'])))
 
     def test_snapshot_should_rebuild_latest_symlink(self):
@@ -75,6 +81,15 @@ class PathTargetTest(TestCase):
 
 
 class SshTargetTest(TestCase):
+    def test_to_rsync(self):
+        notifier = Mock(Notifier)
+        user = 'bart'
+        host = 'example.com'
+        port = 666
+        path = '/var/cache'
+        sut = SshTarget(notifier, user, host, path, port)
+        self.assertEquals(sut.to_rsync(), 'bart@example.com:666/var/cache/latest')
+
     @patch('paramiko.SSHClient', autospec=True)
     def test_is_available(self, m):
         notifier = Mock(Notifier)
@@ -113,24 +128,61 @@ class SshTargetTest(TestCase):
         self.assertNotEquals([], m.return_value.connect.mock_calls)
         m.return_value.connect.assert_called_with(host, port, user, timeout=9)
 
+    @patch('paramiko.SSHClient', autospec=True)
+    def test_snapshot_without_name(self, m):
+        snapshot_name = 'foo_bar'
+        notifier = Mock(Notifier)
+        user = 'bart'
+        host = 'example.com'
+        port = 666
+        path = '/var/cache'
+        sut = SshTarget(notifier, user, host, path, port)
+        sut.snapshot(snapshot_name)
+        m.return_value.connect.assert_called_with(host, port, user, timeout=9)
+        for args in _new_snapshot_args(snapshot_name):
+            m.return_value.__enter__().exec_command.assert_any_call(' '.join(args))
+
 
 class FirstAvailableTargetTest(TestCase):
+    def test_to_rsync(self):
+        notifier = Mock(Notifier)
+        target_1 = PathTarget(notifier, '/tmp/SomeNoneExistentPath')
+        target_2 = PathTarget(notifier, '/tmp')
+        target_3 = PathTarget(notifier, '/tmp')
+        sut = FirstAvailableTarget([target_1, target_2, target_3])
+        self.assertEquals(sut.to_rsync(), target_2.to_rsync())
+        # Try again, so we cover the SUT's internal static cache.
+        self.assertEquals(sut.to_rsync(), target_2.to_rsync())
+
+    def test_snapshot(self):
+        snapshot_name = 'Foo_BAR'
+        notifier = Mock(Notifier)
+        target_1 = PathTarget(notifier, '/tmp/SomeNoneExistentPath')
+        target_2 = Mock(PathTarget)
+        target_3 = PathTarget(notifier, '/tmp')
+        sut = FirstAvailableTarget([target_1, target_2, target_3])
+        sut.snapshot(snapshot_name)
+        target_2.snapshot.assert_called_with(snapshot_name)
+        # Try again, so we cover the SUT's internal static cache.
+        sut.snapshot(snapshot_name)
+        target_2.snapshot.assert_called_with(snapshot_name)
+
     def test_is_available(self):
         notifier = Mock(Notifier)
-        location_1 = PathTarget(notifier, '/tmp/SomeNoneExistentPath')
-        location_2 = PathTarget(notifier, '/tmp')
-        location_3 = PathTarget(notifier, '/tmp')
-        sut = FirstAvailableTarget([location_1, location_2, location_3])
+        target_1 = PathTarget(notifier, '/tmp/SomeNoneExistentPath')
+        target_2 = PathTarget(notifier, '/tmp')
+        target_3 = PathTarget(notifier, '/tmp')
+        sut = FirstAvailableTarget([target_1, target_2, target_3])
         self.assertTrue(sut.is_available())
         # Try again, so we cover the SUT's internal static cache.
         self.assertTrue(sut.is_available())
 
     def test_is_available_unavailable(self):
         notifier = Mock(Notifier)
-        location_1 = PathTarget(notifier, '/tmp/SomeNoneExistentPath')
-        location_2 = PathTarget(notifier, '/tmp/SomeNoneExistentPath')
-        location_3 = PathTarget(notifier, '/tmp/SomeNoneExistentPath')
-        sut = FirstAvailableTarget([location_1, location_2, location_3])
+        target_1 = PathTarget(notifier, '/tmp/SomeNoneExistentPath')
+        target_2 = PathTarget(notifier, '/tmp/SomeNoneExistentPath')
+        target_3 = PathTarget(notifier, '/tmp/SomeNoneExistentPath')
+        sut = FirstAvailableTarget([target_1, target_2, target_3])
         self.assertFalse(sut.is_available())
         # Try again, so we cover the SUT's internal static cache.
         self.assertFalse(sut.is_available())

--- a/backuppy/tests/test_location.py
+++ b/backuppy/tests/test_location.py
@@ -51,12 +51,27 @@ class PathLocationTest(TestCase):
 
 
 class PathTargetTest(TestCase):
-    def test_snapshot(self):
+    def test_snapshot_without_name(self):
         notifier = Mock(Notifier)
         with TemporaryDirectory() as path:
             sut = PathTarget(notifier, path)
             sut.snapshot()
             self.assertTrue(os.path.exists('/'.join([path, 'latest'])))
+
+    def test_snapshot_should_rebuild_latest_symlink(self):
+        snapshot_1_name = 'foo-bar'
+        snapshot_2_name = 'BAZ_QUX'
+        notifier = Mock(Notifier)
+        with TemporaryDirectory() as path:
+            sut = PathTarget(notifier, path)
+            sut.snapshot(snapshot_1_name)
+            sut.snapshot(snapshot_2_name)
+            latest_snapshot_path = subprocess.check_output(['readlink', '-f', '/'.join([path, 'latest'])]).decode(
+                'utf-8').strip()
+            self.assertTrue(os.path.exists('/'.join([path, 'latest'])))
+            self.assertTrue(os.path.exists('/'.join([path, snapshot_1_name])))
+            self.assertTrue(os.path.exists('/'.join([path, snapshot_2_name])))
+            self.assertEquals(latest_snapshot_path, '/'.join([path, snapshot_2_name]))
 
 
 class SshTargetTest(TestCase):

--- a/backuppy/tests/test_task.py
+++ b/backuppy/tests/test_task.py
@@ -1,6 +1,7 @@
-from unittest import TestCase
-
 import os
+import subprocess
+import time
+from unittest import TestCase
 
 from backuppy import assert_path
 from backuppy.location import PathSource, PathTarget
@@ -40,20 +41,57 @@ class BackupTest(TestCase):
 
             # Create the target directory.
             with TemporaryDirectory() as target_path:
-                configuration = Configuration('Foo')
+                configuration = Configuration('Foo', verbose=True)
                 configuration.notifier = Mock(Notifier)
                 configuration.source = PathSource(configuration.notifier, source_path + '/')
                 configuration.target = PathTarget(configuration.notifier, target_path)
+
+                # Back up the first time.
                 result = backup(configuration)
                 self.assertTrue(result)
                 assert_path(self, source_path, target_path + '/latest')
+                real_snapshot_1_path = subprocess.check_output(['readlink', '-f', 'latest'], cwd=target_path).decode(
+                    'utf-8').strip()
+
+                # Sleep for two seconds, so we are (hopefully) absolutely sure the time-based snapshot name generator
+                # will not generate identical names for all snapshots.
+                time.sleep(2)
+
+                result = backup(configuration)
+                self.assertTrue(result)
+                assert_path(self, source_path, target_path + '/latest')
+                real_snapshot_2_path = subprocess.check_output(['readlink', '-f', 'latest'], cwd=target_path).decode(
+                    'utf-8').strip()
+
+                # Ensure both snapshots, made from the same source data, are equal.
+                assert_path(self, real_snapshot_1_path, real_snapshot_2_path)
+
+                # Sleep for two seconds, so we are (hopefully) absolutely sure the time-based snapshot name generator
+                # will not generate identical names for all snapshots.
+                time.sleep(2)
+
+                # Change the source data and create another snapshot. Confirm the first two snapshots remain untouched,\
+                # and only the new one contains the changes.
+                later_file_name = 'some.later.file'
+                later_file_contents = 'These contents were added much later.'
+                with open(os.path.join(source_path, later_file_name), mode='w+t') as f:
+                    f.write(later_file_contents)
+                    f.flush()
+                result = backup(configuration)
+                self.assertTrue(result)
+                assert_path(self, source_path, target_path + '/latest')
+                assert_path(self, real_snapshot_1_path, real_snapshot_2_path)
+                with self.assertRaises(AssertionError):
+                    assert_path(self, source_path, real_snapshot_1_path)
+                with self.assertRaises(AssertionError):
+                    assert_path(self, source_path, real_snapshot_2_path)
 
     def test_backup_with_unavailable_source(self):
         # Create the source directory.
         with TemporaryDirectory() as source_path:
             # Create the target directory.
             with TemporaryDirectory() as target_path:
-                configuration = Configuration('Foo')
+                configuration = Configuration('Foo', verbose=True)
                 configuration.notifier = Mock(Notifier)
                 configuration.source = PathSource(configuration.notifier, source_path + '/NonExistentPath')
                 configuration.target = PathTarget(configuration.notifier, target_path)
@@ -65,7 +103,7 @@ class BackupTest(TestCase):
         with TemporaryDirectory() as source_path:
             # Create the target directory.
             with TemporaryDirectory() as target_path:
-                configuration = Configuration('Foo')
+                configuration = Configuration('Foo', verbose=True)
                 configuration.notifier = Mock(Notifier)
                 configuration.source = PathSource(configuration.notifier, source_path)
                 configuration.target = PathTarget(configuration.notifier, target_path + '/NonExistentPath')


### PR DESCRIPTION
## To-dos
- Use `cp -al` to prepare new snapshot directories. This prevents rsync from having to sync unchanged files.