### PR TITLE
Update the PyPI link to the new production URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Backuppy
 
-[![Build Status](https://travis-ci.org/bartfeenstra/backuppy.svg?branch=master)](https://travis-ci.org/bartfeenstra/backuppy) [![Coverage Status](https://coveralls.io/repos/github/bartfeenstra/backuppy/badge.svg?branch=master)](https://coveralls.io/github/bartfeenstra/backuppy?branch=master) ![Backuppy runs on Python 2.7, 3.5, and 3.6, and on PyPy](https://img.shields.io/badge/Python-2.7%2C%203.5%2C%203.6%2C%20PyPy-blue.svg) [![Latest release](https://img.shields.io/pypi/v/backuppy.svg)](https://pypi.python.org/pypi/backuppy) ![Backuppy is released under the MIT license](https://img.shields.io/github/license/bartfeenstra/backuppy.svg)
+[![Build Status](https://travis-ci.org/bartfeenstra/backuppy.svg?branch=master)](https://travis-ci.org/bartfeenstra/backuppy) [![Coverage Status](https://coveralls.io/repos/github/bartfeenstra/backuppy/badge.svg?branch=master)](https://coveralls.io/github/bartfeenstra/backuppy?branch=master) ![Backuppy runs on Python 2.7, 3.5, and 3.6, and on PyPy](https://img.shields.io/badge/Python-2.7%2C%203.5%2C%203.6%2C%20PyPy-blue.svg) [![Latest release](https://img.shields.io/pypi/v/backuppy.svg)](https://pypi.org/project/backuppy/) ![Backuppy is released under the MIT license](https://img.shields.io/github/license/bartfeenstra/backuppy.svg)
 
 ## About
 Backuppy backs up and restores your data using rsync, allowing different routes to the same, or different destinations.


### PR DESCRIPTION
Update the PyPI link to the new production URL now that Warehouse has been released.